### PR TITLE
changed seed file, lowered password validation length

### DIFF
--- a/config/production_config.json
+++ b/config/production_config.json
@@ -1,0 +1,27 @@
+{
+    "development": {
+      "username": "ulspmzm4cehdnowk",
+      "password": "pkrhm21w27tiy1x3",
+      "database": "ylw935ilg6lase5h",
+      "host": "ctgplw90pifdso61.cbetxkdyhwsb.us-east-1.rds.amazonaws.com",
+      "dialect": "mysql",
+      "operatorsAliases": false
+    },
+    "test": {
+        "username": "ulspmzm4cehdnowk",
+        "password": "pkrhm21w27tiy1x3",
+        "database": "ylw935ilg6lase5h",
+        "host": "ctgplw90pifdso61.cbetxkdyhwsb.us-east-1.rds.amazonaws.com",
+        "dialect": "mysql",
+        "operatorsAliases": false
+      },
+      "production": {
+        "username": "ulspmzm4cehdnowk",
+        "password": "pkrhm21w27tiy1x3",
+        "database": "ylw935ilg6lase5h",
+        "host": "ctgplw90pifdso61.cbetxkdyhwsb.us-east-1.rds.amazonaws.com",
+        "dialect": "mysql",
+        "operatorsAliases": false
+      },
+    
+  }

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,4 +1,4 @@
-USE ylw935ilg6lase5h;
+USE tennis_matchr_db;
 
 INSERT INTO Players (first_name, last_name, username, email, password, rating, createdAt, updatedAt)
 VALUES 

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,17 +1,17 @@
-USE tennis_matchr_db;
+USE tennismatchr_db;
 
-INSERT INTO players (id, first_name, last_name, username, email, password, rating, createdAt, updatedAt)
+INSERT INTO players (first_name, last_name, username, email, password, rating, createdAt, updatedAt)
 VALUES 
-    (1,"Andre", "Agassi", "aagassi", "aagassi@tennis.com", "aa12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (2,"Pete", "Sampras", "psampras", "psampras@tennis.com", "ps12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (3,"Roger", "Federer", "rfederer", "rfederer@tennis.com", "rf12345", 7, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (4,"John", "McEnroe", "jmcenroe", "jmcenroe@tennis.com", "jm12345", 5, "2020-03-29T09:00:00", "2020-03-29T09:00:00");
+    ("Andre", "Agassi", "aagassi", "aagassi@tennis.com", "aa12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Pete", "Sampras", "psampras", "psampras@tennis.com", "ps12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Roger", "Federer", "rfederer", "rfederer@tennis.com", "rf12345", 7, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("John", "McEnroe", "jmcenroe", "jmcenroe@tennis.com", "jm12345", 5, "2020-03-29T09:00:00", "2020-03-29T09:00:00");
 
-INSERT INTO events (id, creator, event_date, event_time, event_type, style, players_count, active, notes, createdAt, updatedAt)
+INSERT INTO events (creator, event_date, event_time, event_type, style, players_count, active, notes, createdAt, updatedAt)
 VALUES 
-    (1,"Andre Agassi","2020-03-30","3:00PM EST","match", "singles", 2, false, "Bring your own tennis balls.", "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (2,"Pete Sampras","2020-04-10","7:00PM EST","match", "doubles", 4, true, "Best of three sets.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (3,"Pete Sampras","2020-04-12","9:00AM EST","practice", "open", 6, true, "Reserved three courts.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (4,"Andre Agassi","2020-03-28","7:00PM EST","match", "singles", 2, false, null,"2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (5,"Roger Federer","2020-04-07","11:00AM EST","tournament", "singles", 10, true, "Email me to be added to the ladder.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
-    (6,"Roger Federer","2020-03-25","4:00PM EST","practice", "singles", 2, false, null,"2020-03-29T09:00:00", "2020-03-29T09:00:00");
+    ("Andre Agassi","2020-03-30","3:00PM EST","match", "singles", 2, false, "Bring your own tennis balls.", "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Pete Sampras","2020-04-10","7:00PM EST","match", "doubles", 4, true, "Best of three sets.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Pete Sampras","2020-04-12","9:00AM EST","practice", "open", 6, true, "Reserved three courts.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Andre Agassi","2020-03-28","7:00PM EST","match", "singles", 2, false, null,"2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Roger Federer","2020-04-07","11:00AM EST","tournament", "singles", 10, true, "Email me to be added to the ladder.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),
+    ("Roger Federer","2020-03-25","4:00PM EST","practice", "singles", 2, false, null,"2020-03-29T09:00:00", "2020-03-29T09:00:00");

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,13 +1,13 @@
-USE tennis_matchr_db;
+USE ylw935ilg6lase5h;
 
-INSERT INTO players (first_name, last_name, username, email, password, rating, createdAt, updatedAt)
+INSERT INTO Players (first_name, last_name, username, email, password, rating, createdAt, updatedAt)
 VALUES 
     ("Andre", "Agassi", "aagassi", "aagassi@tennis.com", "aa12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
     ("Pete", "Sampras", "psampras", "psampras@tennis.com", "ps12345", 6, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
     ("Roger", "Federer", "rfederer", "rfederer@tennis.com", "rf12345", 7, "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
     ("John", "McEnroe", "jmcenroe", "jmcenroe@tennis.com", "jm12345", 5, "2020-03-29T09:00:00", "2020-03-29T09:00:00");
 
-INSERT INTO events (creator, event_date, event_time, event_type, style, players_count, active, notes, createdAt, updatedAt)
+INSERT INTO Events (creator, event_date, event_time, event_type, style, players_count, active, notes, createdAt, updatedAt)
 VALUES 
     ("Andre Agassi","2020-03-30","3:00PM EST","match", "singles", 2, false, "Bring your own tennis balls.", "2020-03-29T09:00:00", "2020-03-29T09:00:00"),
     ("Pete Sampras","2020-04-10","7:00PM EST","match", "doubles", 4, true, "Best of three sets.","2020-03-29T09:00:00", "2020-03-29T09:00:00"),

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,4 +1,4 @@
-USE tennismatchr_db;
+USE tennis_matchr_db;
 
 INSERT INTO players (first_name, last_name, username, email, password, rating, createdAt, updatedAt)
 VALUES 

--- a/models/player.js
+++ b/models/player.js
@@ -36,7 +36,7 @@ module.exports = function (sequelize, DataTypes) {
             type: DataTypes.STRING,
             allowNull: false,
             validate: {
-                len: [8,128]
+                len: [5,128]
             }
         },
         rating: {


### PR DESCRIPTION
Seed files don't need ID for inserts, MySQL automatically assigns an ID to anything added to a table and will continue to sequentially increase ID numbers as more items fill the table. Password length lowered to allow minimum of 5 characters as opposed to the original 8.